### PR TITLE
PLATY-502: Use MdcLoggingExecutionContext to propagate "file referenc…

### DIFF
--- a/app/ScannerModule.scala
+++ b/app/ScannerModule.scala
@@ -27,7 +27,7 @@ class ScannerModule extends Module {
       bind[MessageParser].to[S3EventParser],
       bind[QueueConsumer].to[SqsQueueConsumer],
       bind[PollingJob].to[ScanUploadedFilesFlow],
-      bind[ContinousPoller].toSelf.eagerly(),
+      bind[ContinuousPoller].toSelf.eagerly(),
       bind[ScanningService].to[ClamAvScanningService],
       bind[FileManager].to[S3FileManager],
       bind[InstanceTerminator].to[Ec2InstanceTerminator],

--- a/app/connectors/aws/S3EventParser.scala
+++ b/app/connectors/aws/S3EventParser.scala
@@ -17,8 +17,8 @@
 package connectors.aws
 
 import javax.inject.Inject
-
 import model.{FileUploadEvent, Message, S3ObjectLocation}
+import play.api.Logger
 import play.api.libs.functional.syntax._
 import play.api.libs.json.Reads._
 import play.api.libs.json._
@@ -59,16 +59,30 @@ class S3EventParser @Inject()(implicit ec: ExecutionContext) extends MessagePars
 
   private def asFuture[T](input: JsResult[T]): Future[T] =
     input.fold(
-      errors => Future.failed(new Exception(s"Cannot parse the message ${errors.toString()}")),
+      errors => Future.failed(new Exception(s"Cannot parse the message: [${errors.toString()}].")),
       result => Future.successful(result))
 
   private val ObjectCreatedEventPattern = "ObjectCreated\\:.*".r
 
   private def interpretS3EventMessage(result: S3EventNotification): Future[FileUploadEvent] =
     result.records match {
-      case S3EventNotificationRecord(_, "aws:s3", _, _, ObjectCreatedEventPattern(), s3Details) :: Nil =>
-        Future.successful(FileUploadEvent(S3ObjectLocation(s3Details.bucketName, s3Details.objectKey)))
-      case _ => Future.failed(new Exception(s"Unexpected records in event ${result.records.toString}"))
-    }
+      case S3EventNotificationRecord(_, "aws:s3", _, _, ObjectCreatedEventPattern(), s3Details) :: Nil => {
+        import org.slf4j.MDC
 
+        val event = FileUploadEvent(S3ObjectLocation(s3Details.bucketName, s3Details.objectKey))
+        // Can't rely on MdcLoggingExecutionContext to add file-reference to the MDC, in the code below,
+        // because we don't already have the file-reference value when the thread begins executing.
+        // Therefore add file-reference to the MDC manually. This should be the only part of the code where we need to
+        // manually touch the MDC, since subsequent log statements will have access to the file-reference and can thus
+        // use MdcLoggingExecutionContext / LoggingDetails.
+        try {
+          MDC.put("file-reference", event.location.objectKey)
+          Logger.debug(s"Created FileUploadEvent for objectKey: [${event.location.objectKey}].")
+          Future.successful(event)
+        } finally {
+          MDC.remove("file-reference")
+        }
+      }
+      case _ => Future.failed(new Exception(s"Unexpected records in event: [${result.records.toString}]."))
+    }
 }

--- a/app/services/FileManager.scala
+++ b/app/services/FileManager.scala
@@ -27,9 +27,9 @@ case class ObjectMetadata(items: Map[String, String])
 case class ObjectContent(inputStream: InputStream, length: Long)
 
 trait FileManager {
-  def copyToOutboundBucket(file: S3ObjectLocation): Future[Unit]
-  def writeToQuarantineBucket(file: S3ObjectLocation, content: InputStream, metadata: ObjectMetadata): Future[Unit]
-  def delete(file: S3ObjectLocation): Future[Unit]
-  def getObjectContent(file: S3ObjectLocation): Future[ObjectContent]
-  def getObjectMetadata(file: S3ObjectLocation): Future[ObjectMetadata]
+  def copyToOutboundBucket(objectLocation: S3ObjectLocation): Future[Unit]
+  def writeToQuarantineBucket(objectLocation: S3ObjectLocation, content: InputStream, metadata: ObjectMetadata): Future[Unit]
+  def delete(objectLocation: S3ObjectLocation): Future[Unit]
+  def getObjectContent(objectLocation: S3ObjectLocation): Future[ObjectContent]
+  def getObjectMetadata(objectLocation: S3ObjectLocation): Future[ObjectMetadata]
 }

--- a/app/services/ScanUploadedFilesFlow.scala
+++ b/app/services/ScanUploadedFilesFlow.scala
@@ -52,11 +52,10 @@ class ScanUploadedFilesFlow @Inject()(
 
     outcome.onFailure {
       case error: Exception =>
-        Logger.warn(s"Failed to process message '${message.id}', cause ${error.getMessage}", error)
+        Logger.warn(s"Failed to process message: [${message.id}], cause: [${error.getMessage}].", error)
     }
 
     outcome.recover { case _ => () }
-
   }
 
   private def terminateIfInstanceNotSafe(instanceSafety: InstanceSafety) =

--- a/app/util/logging/LoggingDetails.scala
+++ b/app/util/logging/LoggingDetails.scala
@@ -14,20 +14,20 @@
  * limitations under the License.
  */
 
-package services
+package util.logging
 
 import model.S3ObjectLocation
-import play.api.Logger
+import uk.gov.hmrc.http.HeaderCarrier
 
-import scala.concurrent.Future
+/**
+  * Convenience methods to create a [[uk.gov.hmrc.http.logging.LoggingDetails]] instance, required by [[uk.gov.hmrc.play.http.logging.MdcLoggingExecutionContext]].
+  */
+object LoggingDetails {
+  def fromS3ObjectLocation(s3ObjectLocation: S3ObjectLocation): HeaderCarrier =
+    fromString(s3ObjectLocation.objectKey)
 
-trait VirusNotifier {
-  def notifyFileInfected(file: S3ObjectLocation, details: String): Future[Unit]
-}
-
-object LoggingVirusNotifier extends VirusNotifier {
-  override def notifyFileInfected(file: S3ObjectLocation, details: String) = {
-    Logger.warn(s"Virus detected in file: [$file]. Details: [$details].")
-    Future.successful(())
-  }
+  private def fromString(reference: String): HeaderCarrier =
+    new HeaderCarrier() {
+      override lazy val mdcData: Map[String, String] = super.mdcData + ("file-reference" -> reference)
+    }
 }

--- a/test/services/ContinuousPollerSpec.scala
+++ b/test/services/ContinuousPollerSpec.scala
@@ -30,7 +30,7 @@ import scala.concurrent.Future
 import scala.concurrent.duration._
 import scala.concurrent.duration.FiniteDuration
 
-class ContinousPollerSpec extends UnitSpec with MockitoSugar with Eventually {
+class ContinuousPollerSpec extends UnitSpec with MockitoSugar with Eventually {
 
   implicit def actorSystem = ActorSystem()
 
@@ -65,7 +65,7 @@ class ContinousPollerSpec extends UnitSpec with MockitoSugar with Eventually {
 
       val serviceLifecycle = new DefaultApplicationLifecycle()
 
-      val queuePollingJob = new ContinousPoller(orchestrator, serviceConfiguration)(actorSystem, serviceLifecycle)
+      val queuePollingJob = new ContinuousPoller(orchestrator, serviceConfiguration)(actorSystem, serviceLifecycle)
 
       eventually {
         callCount.get() > 5
@@ -89,7 +89,7 @@ class ContinousPollerSpec extends UnitSpec with MockitoSugar with Eventually {
 
       val serviceLifecycle = new DefaultApplicationLifecycle()
 
-      val queuePollingJob = new ContinousPoller(orchestrator, serviceConfiguration)(actorSystem, serviceLifecycle)
+      val queuePollingJob = new ContinuousPoller(orchestrator, serviceConfiguration)(actorSystem, serviceLifecycle)
 
       eventually {
         callCount.get() > 5


### PR DESCRIPTION
…e" value between execution contexts and include in logging statements via MDC.