### PR TITLE
PLATY-587: Abstract out configuration

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -119,7 +119,8 @@ metrics {
 }
 
 aws {
-  useContainerCredentials = false
+# To run locally, override with -Daws.useContainerCredentials=false
+  useContainerCredentials = true
   accessKeyId = "ENTER YOUR KEY"
   secretAccessKey = "ENYER YOUR SECRET"
   accessKeyId = ${?AWS_ACCESS_KEY_ID}
@@ -133,15 +134,28 @@ aws {
     bucket.quarantine = ${?AWS_S3_BUCKET_QUARANTINE}
   }
   sqs {
-    queue.inbound =  "https://sqs.eu-west-2.amazonaws.com/063874132475/fus-inbound-file-queue-development"
+    queue.inbound =  "SET THE QUEUE"
     queue.inbound = ${?AWS_SQS_QUEUE_INBOUND}
     retry.interval = 20 seconds
   }
 }
 clam.antivirus {
-  host = avscan
+# To run locally, override with -Dclam.antivirus.host=avscan
+  host = localhost
   port = 3310
   timeout = 60000
+}
+logger {
+  resource = application-json-logger.xml
+  uk {
+    gov = info
+  }
+}
+pidfile {
+  path = /dev/null
+}
+run {
+  mode = Prod
 }
 
 processingBatchSize=4


### PR DESCRIPTION
Local running should be the exception, and using container credentials should be the default behaviour.

Changed the default queue value to a value to be input if running locally rather than pointing to a hard-coded dev.