### PR TITLE
PLATY-727 Switched audit configuration to use HTTPS instead of HTTP

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -44,8 +44,6 @@ play.http.filters = "uk.gov.hmrc.play.bootstrap.filters.MicroserviceFilters"
 # Json error handler
 play.http.errorHandler = "uk.gov.hmrc.play.bootstrap.http.JsonErrorHandler"
 
-play.modules.enabled += "uk.gov.hmrc.play.bootstrap.HttpClientModule"
-
 # ClamAV client
 play.modules.enabled += "uk.gov.hmrc.clamav.ClientModule"
 
@@ -219,7 +217,8 @@ Prod {
     consumer {
       baseUri {
         host = datastream.protected.mdtp
-        port = 80
+        port = 443
+	protocol = https
       }
     }
   }


### PR DESCRIPTION
. The service doesn't send any audit events now, but configuration is changed in order to avoid potential suprise in the future