### PR TITLE
PLATOPS-BAU: Remove close() call to inputStream. This stream is owned…

### DIFF
--- a/app/services/FileTypeDetector.scala
+++ b/app/services/FileTypeDetector.scala
@@ -42,7 +42,6 @@ class TikaFileTypeDetector extends FileTypeDetector {
     val detectionResult = detector.detect(tikaInputStream, new Metadata())
 
     tikaInputStream.close()
-    inputStream.close()
 
     MimeType(s"${detectionResult.getType}/${detectionResult.getSubtype}")
   }


### PR DESCRIPTION
… by S3FileManager.withObjectContent, which already takes responsibility for closing the stream after it has been used.